### PR TITLE
feat(hook:exec_cmd): Inherit environment when executing exec_cmd hooks

### DIFF
--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -21,6 +21,7 @@ type SHExecutor struct{}
 // Exec executing shell command, also the passing environment variables to the executor
 func (s SHExecutor) Exec(command string, envVars map[string]string) (results []byte, err error) {
 	cmd := exec.Command(command)
+	cmd.Env = os.Environ()
 	for k, v := range envVars {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}


### PR DESCRIPTION
The scriptability via exec_cmd hooks is currently really limited because important environment variables are missing during hook executions. Examples are: PATH, HOME, KUBECONFIG and others.
This change lets exec_cmd hooks inherit the environment of the caller.

fixes #6 